### PR TITLE
added a new exception to burrow to allow to quit the consumer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
 
     "require-dev" : {
-        "phpunit/phpunit" : "~4.0"
+        "phpunit/phpunit" : "~4.0",
+        "monolog/monolog": "~1.13"
     },
 
     "autoload": {

--- a/examples/async-message-worker.php
+++ b/examples/async-message-worker.php
@@ -9,7 +9,12 @@ if (!isset($argv[1])) {
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+$logger = new \Monolog\Logger('TEST');
+$logger->pushHandler(new \Monolog\Handler\StreamHandler('php://output', 0));
+
 $handler = new \Burrow\RabbitMQ\AmqpAsyncHandler('127.0.0.1', 5672, 'guest', 'guest', $argv[1]);
 $handler->registerConsumer(new \Burrow\Examples\EchoConsumer());
+$handler->setLogger($logger);
+
 $worker = new \Burrow\Worker($handler);
 $worker->run();

--- a/examples/src/EchoConsumer.php
+++ b/examples/src/EchoConsumer.php
@@ -1,8 +1,6 @@
 <?php
 namespace Burrow\Examples;
 
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerInterface;
 use Burrow\QueueConsumer;
 
 class EchoConsumer implements QueueConsumer

--- a/examples/src/ReturnConsumer.php
+++ b/examples/src/ReturnConsumer.php
@@ -1,8 +1,6 @@
 <?php
 namespace Burrow\Examples;
 
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerInterface;
 use Burrow\QueueConsumer;
 
 class ReturnConsumer implements QueueConsumer

--- a/src/Exception/ConsumerException.php
+++ b/src/Exception/ConsumerException.php
@@ -1,0 +1,4 @@
+<?php
+namespace Burrow\Exception;
+
+class ConsumerException extends \Exception {}

--- a/src/RabbitMQ/AbstractAmqpHandler.php
+++ b/src/RabbitMQ/AbstractAmqpHandler.php
@@ -123,16 +123,23 @@ abstract class AbstractAmqpHandler extends AmqpTemplate implements QueueHandler,
                 
                 $currentMemory = memory_get_usage(true);
                 if ($self->getLogger() && $self->getMemory() > 0 && $currentMemory > $self->getMemory()) {
-                    $self->getLogger()->warning('Memory usage increased by ' . ($currentMemory - $self->getMemory()) . 'o (' . $currentMemory . 'o)');
+                    $self->getLogger()
+                        ->warning(
+                            'Memory usage increased',
+                            array (
+                                'bytes_increased_by' => $currentMemory - $self->getMemory(),
+                                'bytes_current_memory' => $currentMemory
+                            )
+                        );
                 }
                 $self->setMemory($currentMemory);
             } catch (\Exception $e) {
                 // beware of infinite loop !
                 $message->delivery_info['channel']->basic_reject($message->delivery_info['delivery_tag'], true);
-                $self->getLogger()->error($e->getMessage());
+                $self->getLogger()->error('Received exception', array('exception' => $e));
 
                 if($e instanceof ConsumerException) {
-                    $this->shutdown();
+                    $self->shutdown();
                 }
             }
         });

--- a/src/RabbitMQ/AmqpTemplate.php
+++ b/src/RabbitMQ/AmqpTemplate.php
@@ -2,8 +2,8 @@
 namespace Burrow\RabbitMQ;
 
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPConnection;
-use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Connection\AMQPLazyConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 abstract class AmqpTemplate
 {
@@ -12,7 +12,7 @@ abstract class AmqpTemplate
     const ESCAPE_MODE_JSON      = 'json';
 
     /**
-     * @var AMQPConnection
+     * @var AMQPStreamConnection
      */
     protected $connection;
 
@@ -37,7 +37,7 @@ abstract class AmqpTemplate
      */
     public function __construct($host, $port, $user, $pass, $escapeMode = self::ESCAPE_MODE_SERIALIZE)
     {
-        $this->connection = new AMQPConnection($host, $port, $user, $pass);
+        $this->connection = new AMQPLazyConnection($host, $port, $user, $pass);
         $this->channel = $this->connection->channel();
         $this->escapeMode = $escapeMode;
     }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -3,6 +3,7 @@ namespace Burrow;
 
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class Worker implements LoggerAwareInterface
 {
@@ -29,6 +30,7 @@ class Worker implements LoggerAwareInterface
     public function __construct(Daemonizable $daemonizable)
     {
         $this->daemonizable = $daemonizable;
+        $this->logger = new NullLogger();
     }
 
     /**
@@ -59,16 +61,12 @@ class Worker implements LoggerAwareInterface
         switch ($signal) {
             case SIGINT:
             case SIGTERM:
-                if ($this->logger) {
-                    $this->logger->alert('Worker killed or terminated', array('sessionId', $this->sessionId));
-                }
+                $this->logger->alert('Worker killed or terminated', array('sessionId', $this->sessionId));
                 $this->daemonizable->shutdown();
                 exit(1);
                 break;
             case SIGHUP:
-                if ($this->logger) {
-                    $this->logger->info('Starting daemon', array('session' => $this->sessionId));
-                }
+                $this->logger->info('Starting daemon', array('session' => $this->sessionId));
                 break;
         }
     }


### PR DESCRIPTION
Allows to stop the worker when receiving one type of exception.

The only other possibility right now to kill the worker from inside the app it launches is to use the instruction "exit;" which is the worse thing anyone can do.

If this type of exception is catched, as any other exception, it won't ack the message (no change here).
