### PR TITLE
Defer channel initialization to the first use of the channel

### DIFF
--- a/src/RabbitMQ/AbstractAmqpHandler.php
+++ b/src/RabbitMQ/AbstractAmqpHandler.php
@@ -115,8 +115,8 @@ abstract class AbstractAmqpHandler extends AmqpTemplate implements QueueHandler,
     {
         $self = $this;
         
-        $this->channel->basic_qos(null, 1, null);
-        $this->channel->basic_consume($this->queueName, '', false, false, false, false, function (AMQPMessage $message) use ($self) {
+        $this->getChannel()->basic_qos(null, 1, null);
+        $this->getChannel()->basic_consume($this->queueName, '', false, false, false, false, function (AMQPMessage $message) use ($self) {
             try {
                 $self->consume($message);
                 $message->delivery_info['channel']->basic_ack($message->delivery_info['delivery_tag']);
@@ -166,11 +166,11 @@ abstract class AbstractAmqpHandler extends AmqpTemplate implements QueueHandler,
         
         $this->logger->info('Starting AMqpAsyncHandler daemon...');
         
-        while (count($this->channel->callbacks) && !$this->stop) {
-            $this->channel->wait();
+        while (count($this->getChannel()->callbacks) && !$this->stop) {
+            $this->getChannel()->wait();
         }
 
-        $this->channel->close();
+        $this->getChannel()->close();
         $this->connection->close();
     }
 

--- a/src/RabbitMQ/AbstractAmqpPublisher.php
+++ b/src/RabbitMQ/AbstractAmqpPublisher.php
@@ -38,7 +38,7 @@ class AbstractAmqpPublisher extends AmqpTemplate implements QueuePublisher
      */
     public function publish($data, $routingKey = '')
     {
-        $this->channel->basic_publish(
+        $this->getChannel()->basic_publish(
             new AMQPMessage($this->escape($data), $this->getMessageProperties()),
             $this->exchangeName,
             $routingKey

--- a/src/RabbitMQ/AmqpAdministrator.php
+++ b/src/RabbitMQ/AmqpAdministrator.php
@@ -11,7 +11,7 @@ class AmqpAdministrator extends AmqpTemplate
     const TOPIC   = 'topic';
     const HEADERS = 'headers';
     const FANOUT  = 'fanout';
-    
+
     /**
      * Declare a persistent queue
      *
@@ -20,9 +20,9 @@ class AmqpAdministrator extends AmqpTemplate
      */
     public function declareSimpleQueue($queueName)
     {
-        $this->channel->queue_declare($queueName, false, true, false, false);
+        $this->getChannel()->queue_declare($queueName, false, true, false, false);
     }
-    
+
     /**
      * Declare an exchange
      *
@@ -32,9 +32,9 @@ class AmqpAdministrator extends AmqpTemplate
      */
     public function declareExchange($queueName, $type = self::FANOUT)
     {
-        $this->channel->exchange_declare($queueName, $type, false, true, false);
+        $this->getChannel()->exchange_declare($queueName, $type, false, true, false);
     }
-    
+
     /**
      * Bind an existing queue to an exchange
      *
@@ -45,9 +45,9 @@ class AmqpAdministrator extends AmqpTemplate
      */
     public function bindQueue($exchange, $queueName, $routingKey = '')
     {
-        $this->channel->queue_bind($queueName, $exchange, $routingKey);
+        $this->getChannel()->queue_bind($queueName, $exchange, $routingKey);
     }
-    
+
     /**
      * Create a persisting queue and bind it to an exchange
      *

--- a/src/RabbitMQ/AmqpSyncPublisher.php
+++ b/src/RabbitMQ/AmqpSyncPublisher.php
@@ -46,8 +46,8 @@ class AmqpSyncPublisher extends AbstractAmqpPublisher implements QueuePublisher
         $this->timeout = $timeout;
 
         $self = $this;
-        list($this->callbackQueue, , ) = $this->channel->queue_declare('', false, false, true, false);
-        $this->channel->basic_consume(
+        list($this->callbackQueue, , ) = $this->getChannel()->queue_declare('', false, false, true, false);
+        $this->getChannel()->basic_consume(
             $this->callbackQueue, '', false, false, false, false, function (AMQPMessage $message) use ($self) {
                 if ($message->get('correlation_id') == $self->getCorrelationId()) {
                     $self->setResponse($this->unescape($message->body));
@@ -88,7 +88,7 @@ class AmqpSyncPublisher extends AbstractAmqpPublisher implements QueuePublisher
 
         while (!$this->response && $elapsedTime < $msTimeout) {
             $waitTimeout = ceil(($msTimeout - $elapsedTime) / 1000);
-            $this->channel->wait(null, false, $waitTimeout);
+            $this->getChannel()->wait(null, false, $waitTimeout);
             $elapsedTime = microtime(true) - $start;
         }
 

--- a/src/RabbitMQ/AmqpTemplate.php
+++ b/src/RabbitMQ/AmqpTemplate.php
@@ -17,9 +17,9 @@ abstract class AmqpTemplate
     protected $connection;
 
     /**
-     * @var AMQPChannel
+     * @var AMQPChannel|null
      */
-    protected $channel;
+    private $channel;
 
     /**
      * @var string
@@ -38,7 +38,6 @@ abstract class AmqpTemplate
     public function __construct($host, $port, $user, $pass, $escapeMode = self::ESCAPE_MODE_SERIALIZE)
     {
         $this->connection = new AMQPLazyConnection($host, $port, $user, $pass);
-        $this->channel = $this->connection->channel();
         $this->escapeMode = $escapeMode;
     }
 
@@ -80,5 +79,14 @@ abstract class AmqpTemplate
                 break;
         }
         return $unescapedMessage;
+    }
+
+    protected function getChannel()
+    {
+        if(null === $this->channel) {
+            $this->channel = $this->connection->channel();
+        }
+
+        return $this->channel;
     }
 }


### PR DESCRIPTION
The connection wasn't lazy because the channel was retrieved from the connection
in the constructor.
