### PR TITLE
feat: allow to send metrics to StatsD or DogStatsD

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,48 @@ $worker->run();
 In the command-line, launch both scripts from a different terminal, the message 'my_message', should be displayed in the
 publisher terminal.
 
+Events
+-------
+
+You can add your emitter to subscribe events:
+- [DaemonStart](src/Event/DaemonStarted.php)
+- [DaemonStopped](src/Event/DaemonStopped.php)
+- [MessageReceived](src/Event/MessageReceived.php)
+- [MessageConsumed](src/Event/MessageStopped.php)
+
+```php
+$emitter = new League\Event\Emitter();
+$emitter->addListener(new MyListener());
+
+new QueueHandlingDaemon([..], $emitter);
+```
+
+Metrics
+-------
+
+Based on events, you can subscribe a built-in metric publisher which will send this metrics:
+- `daemon.started`
+- `daemon.stopped`
+- `daemon.message_received`
+- `daemon.message_consumed`
+
+There is an implementation for StatsD and DogStatsD.
+
+```php
+$config = ['host' => 'host', 'port' => 'port'];
+
+// StatsD
+$metricService = MetricServiceFactory::create('statsd', $config);
+// DogStatsD
+$tags = ['service' => 'myService']; // This tags will be sent with all the metrics
+$metricService = MetricServiceFactory::create('dogstats', $config, $tags);
+
+$emitter = new League\Event\Emitter();
+$emitter->useListenerProvider(new SendMetricSubscriber($metricService));
+
+new QueueHandlingDaemon([..], $emitter);
+```
+
 Examples
 --------
 

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,14 @@
         "psr/log": "~1.0",
         "symfony/console": "^2.8|^3.0|^4.0",
         "beberlei/assert": "^2.6",
+        "beberlei/metrics": "^2.8",
         "evaneos/daemon": "^2.0",
+        "league/event": "^2.2",
         "ext-pcntl": "*"
     },
     "require-dev" : {
         "phpunit/phpunit" : "~4.0|~5.0",
         "monolog/monolog": "~1.13",
-        "league/event": "^2.1",
         "mockery/mockery": "^0.9.4",
         "fzaninotto/faker": "^1.6",
         "symfony/process": "^3.2",
@@ -41,10 +42,6 @@
             "Burrow\\Test\\Validation\\": "tests/validation/",
             "Burrow\\Test\\Integration\\": "tests/integration/"
         }
-    },
-
-    "suggest": {
-        "league/event": "Allows to deal with event within your application."
     },
 
     "bin": [ "bin/burrow" ],

--- a/src/Clock.php
+++ b/src/Clock.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Burrow;
+
+interface Clock
+{
+    /**
+     * @return float
+     */
+    public function timestampInMs();
+}

--- a/src/Event/DaemonStarted.php
+++ b/src/Event/DaemonStarted.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Burrow\Event;
+
+use League\Event\EmitterAwareTrait;
+use League\Event\EventInterface;
+
+class DaemonStarted implements EventInterface
+{
+    use EmitterAwareTrait;
+
+    const NAME = 'daemon.started';
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    public function stopPropagation()
+    {
+        return false;
+    }
+
+    public function isPropagationStopped()
+    {
+        return false;
+    }
+}

--- a/src/Event/DaemonStopped.php
+++ b/src/Event/DaemonStopped.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Burrow\Event;
+
+use League\Event\EmitterAwareTrait;
+use League\Event\EventInterface;
+
+class DaemonStopped implements EventInterface
+{
+    use EmitterAwareTrait;
+
+    const NAME = 'daemon.stopped';
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    public function stopPropagation()
+    {
+        return false;
+    }
+
+    public function isPropagationStopped()
+    {
+        return false;
+    }
+}

--- a/src/Event/Listener/ListenerException.php
+++ b/src/Event/Listener/ListenerException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Burrow\Event\Listener;
+
+use League\Event\EventInterface;
+
+class ListenerException extends \Exception
+{
+    public static function badEventGiven(EventInterface $event)
+    {
+        return new self(sprintf('Bad event given %s', $event->getName()));
+    }
+}

--- a/src/Event/Listener/Metric/SendMetricListenerProvider.php
+++ b/src/Event/Listener/Metric/SendMetricListenerProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Burrow\Event\Listener\Metric;
+
+use Burrow\Event\DaemonStarted;
+use Burrow\Event\DaemonStopped;
+use Burrow\Event\MessageConsumed;
+use Burrow\Event\MessageReceived;
+use Burrow\Metric\MetricService;
+use League\Event\ListenerAcceptorInterface;
+use League\Event\ListenerProviderInterface;
+
+class SendMetricListenerProvider implements ListenerProviderInterface
+{
+    /** @var MetricService  */
+    private $metricService;
+
+    /**
+     * SendMetricSubscriber constructor.
+     *
+     * @param MetricService $metricService
+     */
+    public function __construct(MetricService $metricService)
+    {
+        $this->metricService = $metricService;
+    }
+
+    /**
+     * @param ListenerAcceptorInterface $listenerAcceptor
+     *
+     * @return ListenerProviderInterface|void
+     */
+    public function provideListeners(ListenerAcceptorInterface $listenerAcceptor)
+    {
+        $listenerAcceptor->addListener(DaemonStarted::NAME, new SendMetricOnDaemonStarted($this->metricService));
+        $listenerAcceptor->addListener(DaemonStopped::NAME, new SendMetricOnDaemonStopped($this->metricService));
+        $listenerAcceptor->addListener(MessageReceived::NAME, new SendMetricOnMessageReceived($this->metricService));
+
+        $sendMetricOnMessageConsumed = new SendMetricOnMessageConsumed($this->metricService);
+        $listenerAcceptor->addListener(MessageReceived::NAME, $sendMetricOnMessageConsumed);
+        $listenerAcceptor->addListener(MessageConsumed::NAME, $sendMetricOnMessageConsumed);
+    }
+}

--- a/src/Event/Listener/Metric/SendMetricOnDaemonStarted.php
+++ b/src/Event/Listener/Metric/SendMetricOnDaemonStarted.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Burrow\Event\Listener\Metric;
+
+use Burrow\Event\DaemonStarted;
+use Burrow\Event\Listener\ListenerException;
+use Burrow\Metric\MetricService;
+use League\Event\EventInterface;
+use League\Event\ListenerInterface;
+
+class SendMetricOnDaemonStarted implements ListenerInterface
+{
+    /** @var MetricService */
+    private $metricService;
+
+    /**
+     * SendMetricOnDaemonStarted constructor.
+     *
+     * @param MetricService $metricService
+     */
+    public function __construct(MetricService $metricService)
+    {
+        $this->metricService = $metricService;
+    }
+
+    /**
+     * @param EventInterface $event
+     *
+     * @throws ListenerException
+     */
+    public function handle(EventInterface $event)
+    {
+        if (!($event instanceof DaemonStarted)) {
+            throw ListenerException::badEventGiven($event);
+        }
+
+        $this->metricService->increment('daemon.started');
+    }
+
+    public function isListener($listener)
+    {
+        return $listener === $this;
+    }
+}

--- a/src/Event/Listener/Metric/SendMetricOnDaemonStopped.php
+++ b/src/Event/Listener/Metric/SendMetricOnDaemonStopped.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Burrow\Event\Listener\Metric;
+
+use Burrow\Event\DaemonStopped;
+use Burrow\Event\Listener\ListenerException;
+use Burrow\Metric\MetricService;
+use League\Event\EventInterface;
+use League\Event\ListenerInterface;
+
+class SendMetricOnDaemonStopped implements ListenerInterface
+{
+    /** @var MetricService */
+    private $metricService;
+
+    /**
+     * SendMetricOnDaemonStarted constructor.
+     *
+     * @param MetricService $metricService
+     */
+    public function __construct(MetricService $metricService)
+    {
+        $this->metricService = $metricService;
+    }
+
+    /**
+     * @param EventInterface $event
+     *
+     * @throws ListenerException
+     */
+    public function handle(EventInterface $event)
+    {
+        if (!($event instanceof DaemonStopped)) {
+            throw ListenerException::badEventGiven($event);
+        }
+
+        $this->metricService->increment('daemon.stopped');
+    }
+
+    public function isListener($listener)
+    {
+        return $listener === $this;
+    }
+}

--- a/src/Event/Listener/Metric/SendMetricOnMessageConsumed.php
+++ b/src/Event/Listener/Metric/SendMetricOnMessageConsumed.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Burrow\Event\Listener\Metric;
+
+use Burrow\Clock;
+use Burrow\Event\Listener\ListenerException;
+use Burrow\Event\MessageConsumed;
+use Burrow\Event\MessageReceived;
+use Burrow\Metric\MetricService;
+use Burrow\RealClock;
+use League\Event\EventInterface;
+use League\Event\ListenerInterface;
+
+class SendMetricOnMessageConsumed implements ListenerInterface
+{
+    /** @var MetricService */
+    private $metricService;
+
+    /** @var Clock */
+    private $clock;
+
+    /** @var null|float */
+    private $messageReceivedAt;
+
+    /**
+     * SendMetricOnMessageConsumed constructor.
+     *
+     * @param MetricService $metricService
+     * @param Clock|null    $clock
+     */
+    public function __construct(MetricService $metricService, Clock $clock = null)
+    {
+        $this->metricService = $metricService;
+        $this->clock = $clock ?: new RealClock();
+    }
+
+    /**
+     * @param EventInterface | MessageConsumed $event
+     *
+     * @throws ListenerException
+     */
+    public function handle(EventInterface $event)
+    {
+        if ($event instanceof MessageReceived) {
+            $this->messageReceivedAt = $this->clock->timestampInMs();
+            return;
+        }
+
+        if (!($event instanceof MessageConsumed)) {
+            throw ListenerException::badEventGiven($event);
+        }
+
+        $this->metricService->timing(
+            'daemon.message_consumed',
+            $this->clock->timestampInMs() - $this->messageReceivedAt
+        );
+    }
+
+    public function isListener($listener)
+    {
+        return $listener === $this;
+    }
+}

--- a/src/Event/Listener/Metric/SendMetricOnMessageReceived.php
+++ b/src/Event/Listener/Metric/SendMetricOnMessageReceived.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Burrow\Event\Listener\Metric;
+
+use Burrow\Event\Listener\ListenerException;
+use Burrow\Event\MessageReceived;
+use Burrow\Metric\MetricService;
+use League\Event\EventInterface;
+use League\Event\ListenerInterface;
+
+class SendMetricOnMessageReceived implements ListenerInterface
+{
+    /** @var MetricService */
+    private $metricService;
+
+    /**
+     * SendMetricOnDaemonStarted constructor.
+     *
+     * @param MetricService $metricService
+     */
+    public function __construct(MetricService $metricService)
+    {
+        $this->metricService = $metricService;
+    }
+
+    /**
+     * @param EventInterface $event
+     *
+     * @throws ListenerException
+     */
+    public function handle(EventInterface $event)
+    {
+        if (!($event instanceof MessageReceived)) {
+            throw ListenerException::badEventGiven($event);
+        }
+
+        $this->metricService->increment('daemon.message_received');
+    }
+
+    public function isListener($listener)
+    {
+        return $listener === $this;
+    }
+}

--- a/src/Event/MessageConsumed.php
+++ b/src/Event/MessageConsumed.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Burrow\Event;
+
+use League\Event\EmitterAwareTrait;
+use League\Event\EventInterface;
+
+class MessageConsumed implements EventInterface
+{
+    use EmitterAwareTrait;
+
+    const NAME = 'message.consumed';
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    public function stopPropagation()
+    {
+        return false;
+    }
+
+    public function isPropagationStopped()
+    {
+        return false;
+    }
+}

--- a/src/Event/MessageReceived.php
+++ b/src/Event/MessageReceived.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Burrow\Event;
+
+use League\Event\EmitterAwareTrait;
+use League\Event\EventInterface;
+
+class MessageReceived implements EventInterface
+{
+    use EmitterAwareTrait;
+
+    const NAME = 'message.received';
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    public function stopPropagation()
+    {
+        return false;
+    }
+
+    public function isPropagationStopped()
+    {
+        return false;
+    }
+}

--- a/src/Event/NullEmitter.php
+++ b/src/Event/NullEmitter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Burrow\Event;
+
+use League\Event\EmitterInterface;
+use League\Event\EmitterTrait;
+use League\Event\GeneratorInterface;
+
+class NullEmitter implements EmitterInterface
+{
+    use EmitterTrait;
+
+    public function hasListeners($event)
+    {
+        return false;
+    }
+
+    public function getListeners($event)
+    {
+        return [];
+    }
+
+    public function emitBatch(array $events)
+    {
+        return [];
+    }
+
+    public function emitGeneratedEvents(GeneratorInterface $generator)
+    {
+    }
+}

--- a/src/Metric/DogStatsDMetricService.php
+++ b/src/Metric/DogStatsDMetricService.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Burrow\Metric;
+
+use Beberlei\Metrics\Collector\DogStatsD as Collector;
+
+class DogStatsDMetricService implements MetricService
+{
+    /** @var Collector */
+    private $collector;
+
+    /** @var array */
+    private $tags;
+
+    /**
+     * MetricService constructor.
+     *
+     * @param Collector $collector
+     * @param array     $tags
+     */
+    public function __construct(Collector $collector, array $tags = [])
+    {
+        $this->collector = $collector;
+        $this->tags = $tags;
+    }
+
+    /**
+     * @param $key
+     */
+    public function increment($key)
+    {
+        $this->collector->increment($key, $this->tags);
+        $this->collector->flush();
+    }
+
+    /**
+     * @param $key
+     * @param float $timeInMs
+     */
+    public function timing($key, $timeInMs)
+    {
+        $this->collector->timing($key, $timeInMs, $this->tags);
+        $this->collector->flush();
+    }
+}

--- a/src/Metric/MetricService.php
+++ b/src/Metric/MetricService.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Burrow\Metric;
+
+interface MetricService
+{
+    /**
+     * @param $key
+     */
+    public function increment($key);
+
+    /**
+     * @param $key
+     * @param float $timeInMs
+     */
+    public function timing($key, $timeInMs);
+}

--- a/src/Metric/MetricServiceFactory.php
+++ b/src/Metric/MetricServiceFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Burrow\Metric;
+
+use Beberlei\Metrics\Collector\DogStatsD;
+use Beberlei\Metrics\Collector\StatsD;
+use Beberlei\Metrics\Factory;
+use Beberlei\Metrics\MetricsException;
+
+class MetricServiceFactory
+{
+    /**
+     * @param       $type
+     * @param array $options
+     * @param array $contextualTags
+     *
+     * @return MetricService
+     * @throws MetricsException
+     * @throws \Exception
+     */
+    public static function create($type, $options = [], $contextualTags = [])
+    {
+        $collector = Factory::create($type, $options);
+
+        switch ($type) {
+            case 'dogstatsd':
+                /** @var DogStatsD $collector */
+                return new DogStatsDMetricService($collector, $contextualTags);
+            case 'statsd':
+                /** @var StatsD $collector */
+                return new StatsDMetricService($collector);
+        }
+
+        throw new \Exception(sprintf('MetricService for %s is not implemented', $type));
+    }
+}

--- a/src/Metric/StatsDMetricService.php
+++ b/src/Metric/StatsDMetricService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Burrow\Metric;
+
+use Beberlei\Metrics\Collector\StatsD as Collector;
+
+class StatsDMetricService implements MetricService
+{
+    /** @var Collector */
+    private $collector;
+
+    /**
+     * MetricService constructor.
+     *
+     * @param Collector $collector
+     */
+    public function __construct(Collector $collector)
+    {
+        $this->collector = $collector;
+    }
+
+    /**
+     * @param $key
+     */
+    public function increment($key)
+    {
+        $this->collector->increment($key);
+        $this->collector->flush();
+    }
+
+    /**
+     * @param $key
+     * @param float $timeInMs
+     */
+    public function timing($key, $timeInMs)
+    {
+        $this->collector->timing($key, $timeInMs);
+        $this->collector->flush();
+    }
+}

--- a/src/RealClock.php
+++ b/src/RealClock.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Burrow;
+
+class RealClock implements Clock
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function timestampInMs()
+    {
+        return microtime(true);
+    }
+}

--- a/tests/unit/Event/Listener/Metric/Metric/SendMetricListenerSubscriberTest.php
+++ b/tests/unit/Event/Listener/Metric/Metric/SendMetricListenerSubscriberTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Burrow\Test\Event\Listener\Metric;
+
+use Burrow\Event\Listener\Metric\SendMetricOnDaemonStarted;
+use Burrow\Event\Listener\Metric\SendMetricOnDaemonStopped;
+use Burrow\Event\Listener\Metric\SendMetricOnMessageConsumed;
+use Burrow\Event\Listener\Metric\SendMetricOnMessageReceived;
+use Burrow\Event\Listener\Metric\SendMetricListenerProvider;
+use Burrow\Metric\MetricService;
+use League\Event\ListenerAcceptorInterface;
+use Mockery\Matcher\MustBe;
+use Mockery\Mock;
+
+class SendMetricListenerSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var SendMetricListenerProvider */
+    private $serviceUnderTest;
+
+    /** @var MetricService */
+    private $metricService;
+
+    /** @var ListenerAcceptorInterface | Mock */
+    private $listenerAcceptator;
+
+    public function setUp()
+    {
+        $this->metricService = \Mockery::mock(MetricService::class);
+        $this->listenerAcceptator = \Mockery::mock(ListenerAcceptorInterface::class);
+
+        $this->serviceUnderTest = new SendMetricListenerProvider(
+            $this->metricService
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itProvideListeners()
+    {
+        $this->assertListenersAdded();
+
+        $this->serviceUnderTest->provideListeners($this->listenerAcceptator);
+    }
+
+    private function assertListenersAdded()
+    {
+        $this->listenerAcceptator
+            ->shouldReceive('addListener')
+            ->with('daemon.started', new MustBe(new SendMetricOnDaemonStarted($this->metricService)))
+            ->once();
+
+        $this->listenerAcceptator
+            ->shouldReceive('addListener')
+            ->with('daemon.stopped', new MustBe(new SendMetricOnDaemonStopped($this->metricService)))
+            ->once();
+
+        $this->listenerAcceptator
+            ->shouldReceive('addListener')
+            ->with('message.received', new MustBe(new SendMetricOnMessageReceived($this->metricService)))
+            ->once();
+
+        $sendMetricOnMessageConsumed = new SendMetricOnMessageConsumed($this->metricService);
+
+        $this->listenerAcceptator
+            ->shouldReceive('addListener')
+            ->with('message.received', new MustBe($sendMetricOnMessageConsumed))
+            ->once();
+
+        $this->listenerAcceptator
+            ->shouldReceive('addListener')
+            ->with('message.consumed', new MustBe($sendMetricOnMessageConsumed))
+            ->once();
+    }
+
+    /**
+     * Close
+     */
+    public function tearDown()
+    {
+        \Mockery::close();
+    }
+}

--- a/tests/unit/Event/Listener/Metric/Metric/SendMetricOnDaemonStartedTest.php
+++ b/tests/unit/Event/Listener/Metric/Metric/SendMetricOnDaemonStartedTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Burrow\Test\Event\Listener\Metric;
+
+use Burrow\Event\DaemonStarted;
+use Burrow\Event\Listener\Metric\SendMetricOnDaemonStarted;
+use Burrow\Metric\MetricService;
+use League\Event\Event;
+use Mockery\Mock;
+
+class SendMetricOnDaemonStartedTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var MetricService | Mock */
+    private $metricService;
+
+    /** @var SendMetricOnDaemonStarted */
+    private $serviceUnderTest;
+
+    public function setUp()
+    {
+        $this->metricService = \Mockery::mock(MetricService::class);
+
+        $this->serviceUnderTest = new SendMetricOnDaemonStarted($this->metricService);
+    }
+
+    /**
+     * @test
+     */
+    public function itIncrementDaemonStart()
+    {
+        $this->assertIncrementCalledOnMetricService();
+
+        $this->serviceUnderTest->handle(new DaemonStarted());
+    }
+
+    /**
+     * @test
+     * @expectedException \Burrow\Event\Listener\ListenerException
+     */
+    public function itThrowExceptionWhenBadEventIsGiven()
+    {
+        $this->serviceUnderTest->handle(new Event('anEvent'));
+    }
+
+    private function assertIncrementCalledOnMetricService()
+    {
+        $this->metricService
+            ->shouldReceive('increment')
+            ->with('daemon.started')
+            ->once();
+    }
+
+    /**
+     * Close
+     */
+    public function tearDown()
+    {
+        \Mockery::close();
+    }
+}

--- a/tests/unit/Event/Listener/Metric/Metric/SendMetricOnDaemonStoppedTest.php
+++ b/tests/unit/Event/Listener/Metric/Metric/SendMetricOnDaemonStoppedTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Burrow\Test\Event\Listener\Metric;
+
+use Burrow\Event\DaemonStopped;
+use Burrow\Event\Listener\Metric\SendMetricOnDaemonStopped;
+use Burrow\Metric\MetricService;
+use League\Event\Event;
+use Mockery\Mock;
+
+class SendMetricOnDaemonStoppedTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var MetricService | Mock */
+    private $metricService;
+
+    /** @var SendMetricOnDaemonStopped */
+    private $serviceUnderTest;
+
+    public function setUp()
+    {
+        $this->metricService = \Mockery::mock(MetricService::class);
+
+        $this->serviceUnderTest = new SendMetricOnDaemonStopped($this->metricService);
+    }
+
+    /**
+     * @test
+     */
+    public function itIncrementDaemonStop()
+    {
+        $this->assertIncrementCalledOnMetricService();
+
+        $this->serviceUnderTest->handle(new DaemonStopped());
+    }
+
+    /**
+     * @test
+     * @expectedException \Burrow\Event\Listener\ListenerException
+     */
+    public function itThrowExceptionWhenBadEventIsGiven()
+    {
+        $this->serviceUnderTest->handle(new Event('anEvent'));
+    }
+
+    private function assertIncrementCalledOnMetricService()
+    {
+        $this->metricService
+            ->shouldReceive('increment')
+            ->with('daemon.stopped')
+            ->once();
+    }
+
+    /**
+     * Close
+     */
+    public function tearDown()
+    {
+        \Mockery::close();
+    }
+}

--- a/tests/unit/Event/Listener/Metric/Metric/SendMetricOnMessageConsumedTest.php
+++ b/tests/unit/Event/Listener/Metric/Metric/SendMetricOnMessageConsumedTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Burrow\Test\Event\Listener\Metric;
+
+use Burrow\Event\Listener\Metric\SendMetricOnMessageConsumed;
+use Burrow\Event\MessageConsumed;
+use Burrow\Event\MessageReceived;
+use Burrow\Metric\MetricService;
+use Burrow\Test\FrozenClock;
+use League\Event\Event;
+use Mockery\Mock;
+
+class SendMetricOnMessageConsumedTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var MetricService | Mock */
+    private $metricService;
+
+    /** @var SendMetricOnMessageConsumed */
+    private $serviceUnderTest;
+
+    public function setUp()
+    {
+        $clock = new FrozenClock(\DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2018-12-17 00:00:00'));
+        $this->metricService = \Mockery::mock(MetricService::class);
+
+        $this->serviceUnderTest = new SendMetricOnMessageConsumed($this->metricService, $clock);
+    }
+
+    /**
+     * @test
+     */
+    public function itStoreTimeWhenMessageIsReceivedAndSendTimeWhenMessageConsumed()
+    {
+        $this->assertIncrementCalledOnMetricService();
+
+        $this->serviceUnderTest->handle(new MessageReceived());
+        $this->serviceUnderTest->handle(new MessageConsumed());
+    }
+
+    /**
+     * @test
+     * @expectedException \Burrow\Event\Listener\ListenerException
+     */
+    public function itThrowExceptionWhenBadEventIsGiven()
+    {
+        $this->serviceUnderTest->handle(new Event('anEvent'));
+    }
+
+    private function assertIncrementCalledOnMetricService()
+    {
+        $this->metricService
+            ->shouldReceive('timing')
+            ->with('daemon.message_consumed', 0)
+            ->once();
+    }
+
+    /**
+     * Close
+     */
+    public function tearDown()
+    {
+        \Mockery::close();
+    }
+}

--- a/tests/unit/Event/Listener/Metric/Metric/SendMetricOnMessageReceivedTest.php
+++ b/tests/unit/Event/Listener/Metric/Metric/SendMetricOnMessageReceivedTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Burrow\Test\Event\Listener\Metric;
+
+use Burrow\Event\Listener\Metric\SendMetricOnMessageReceived;
+use Burrow\Event\MessageReceived;
+use Burrow\Metric\MetricService;
+use League\Event\Event;
+use Mockery\Mock;
+
+class SendMetricOnMessageReceivedTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var MetricService | Mock */
+    private $metricService;
+
+    /** @var SendMetricOnMessageReceived */
+    private $serviceUnderTest;
+
+    public function setUp()
+    {
+        $this->metricService = \Mockery::mock(MetricService::class);
+
+        $this->serviceUnderTest = new SendMetricOnMessageReceived($this->metricService);
+    }
+
+    /**
+     * @test
+     */
+    public function itIncrementMessageReceived()
+    {
+        $this->assertIncrementCalledOnMetricService();
+
+        $this->serviceUnderTest->handle(new MessageReceived());
+    }
+
+    /**
+     * @test
+     * @expectedException \Burrow\Event\Listener\ListenerException
+     */
+    public function itThrowExceptionWhenBadEventIsGiven()
+    {
+        $this->serviceUnderTest->handle(new Event('anEvent'));
+    }
+
+    private function assertIncrementCalledOnMetricService()
+    {
+        $this->metricService
+            ->shouldReceive('increment')
+            ->with('daemon.message_received')
+            ->once();
+    }
+
+    /**
+     * Close
+     */
+    public function tearDown()
+    {
+        \Mockery::close();
+    }
+}

--- a/tests/unit/FrozenClock.php
+++ b/tests/unit/FrozenClock.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Burrow\Test;
+
+use Burrow\Clock;
+
+class FrozenClock implements Clock
+{
+    /** @var \DateTimeImmutable */
+    private $time;
+
+    /**
+     * FrozenClock constructor.
+     *
+     * @param \DateTimeImmutable $time
+     */
+    public function __construct(\DateTimeImmutable $time)
+    {
+        $this->time = $time;
+    }
+
+    /**
+     * @return float
+     */
+    public function timestampInMs()
+    {
+        return (float) $this->time->getTimestamp();
+    }
+}

--- a/tests/unit/Metric/DogStatsDMetricServiceTest.php
+++ b/tests/unit/Metric/DogStatsDMetricServiceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Burrow\Test\Metric;
+
+use Beberlei\Metrics\Collector\DogStatsD;
+use Burrow\Metric\DogStatsDMetricService;
+use Burrow\Metric\StatsDMetricService;
+use Mockery\Mock;
+
+class DogStatsDMetricServiceTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var DogStatsD | Mock */
+    private $collector;
+
+    /** @var StatsDMetricService */
+    private $serviceUnderTest;
+
+    /** @var array */
+    private $tags;
+
+    public function setUp()
+    {
+        $this->collector = \Mockery::mock(DogStatsD::class);
+
+        $this->tags = ['tag' => 'value'];
+
+        $this->serviceUnderTest = new DogStatsDMetricService($this->collector, $this->tags);
+    }
+
+    /**
+     * @test
+     */
+    public function itSendIncrement()
+    {
+        $this->collector
+            ->shouldReceive('increment')
+            ->with('key', $this->tags)
+            ->once();
+
+        $this->collector
+            ->shouldReceive('flush')
+            ->once();
+
+        $this->serviceUnderTest->increment('key');
+    }
+
+    /**
+     * @test
+     */
+    public function itSendTiming()
+    {
+        $this->collector
+            ->shouldReceive('timing')
+            ->with('key', 0.01, $this->tags)
+            ->once();
+
+        $this->collector
+            ->shouldReceive('flush')
+            ->once();
+
+        $this->serviceUnderTest->timing('key', 0.01);
+    }
+
+    /**
+     * Close
+     */
+    public function tearDown()
+    {
+        \Mockery::close();
+    }
+}

--- a/tests/unit/Metric/MetricServiceFactoryTest.php
+++ b/tests/unit/Metric/MetricServiceFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Burrow\Test\Metric;
+
+
+use Burrow\Metric\DogStatsDMetricService;
+use Burrow\Metric\MetricServiceFactory;
+use Burrow\Metric\StatsDMetricService;
+
+class MetricServiceFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function itCreatesDogstatsdMetricService()
+    {
+        $service = MetricServiceFactory::create('dogstatsd');
+
+        self::assertInstanceOf(DogStatsDMetricService::class, $service);
+    }
+    /**
+     * @test
+     */
+    public function itCreatesStatsdMetricService()
+    {
+        $service = MetricServiceFactory::create('statsd');
+
+        self::assertInstanceOf(StatsDMetricService::class, $service);
+    }
+
+    /**
+     * Close
+     */
+    public function tearDown()
+    {
+        \Mockery::close();
+    }
+}

--- a/tests/unit/Metric/StatsDMetricServiceTest.php
+++ b/tests/unit/Metric/StatsDMetricServiceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Burrow\Test\Metric;
+
+use Beberlei\Metrics\Collector\StatsD;
+use Burrow\Metric\StatsDMetricService;
+use Mockery\Mock;
+
+class StatsDMetricServiceTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var StatsD | Mock */
+    private $collector;
+
+    /** @var StatsDMetricService */
+    private $serviceUnderTest;
+
+    public function setUp()
+    {
+        $this->collector = \Mockery::mock(StatsD::class);
+
+        $this->serviceUnderTest = new StatsDMetricService($this->collector);
+    }
+
+    /**
+     * @test
+     */
+    public function itSendIncrement()
+    {
+        $this->collector
+            ->shouldReceive('increment')
+            ->with('key')
+            ->once();
+
+        $this->collector
+            ->shouldReceive('flush')
+            ->once();
+
+        $this->serviceUnderTest->increment('key');
+    }
+
+    /**
+     * @test
+     */
+    public function itSendTiming()
+    {
+        $this->collector
+            ->shouldReceive('timing')
+            ->with('key', 0.01)
+            ->once();
+
+        $this->collector
+            ->shouldReceive('flush')
+            ->once();
+
+        $this->serviceUnderTest->timing('key', 0.01);
+    }
+
+    /**
+     * Close
+     */
+    public function tearDown()
+    {
+        \Mockery::close();
+    }
+}


### PR DESCRIPTION
Add 4 metrics:
- `daemon.started`
- `daemon.stopped`
- `daemon.message_received`
- `daemon.message_consumed`
