### PR TITLE
refactor: add processing time along side message consumed

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,11 @@ Metrics
 -------
 
 Based on events, you can subscribe a built-in metric publisher which will send this metrics:
-- `daemon.started`
-- `daemon.stopped`
-- `daemon.message_received`
-- `daemon.message_consumed`
+- `daemon.started` (increment)
+- `daemon.stopped` (increment)
+- `daemon.message_received` (increment)
+- `daemon.message_consumed` (increment)
+- `daemon.message_processing_time` (timing)
 
 There is an implementation for StatsD and DogStatsD.
 

--- a/src/Daemon/QueueHandlingDaemon.php
+++ b/src/Daemon/QueueHandlingDaemon.php
@@ -93,7 +93,6 @@ class QueueHandlingDaemon implements Daemon, LoggerAwareInterface
         );
 
         $this->stop();
-        $this->eventEmitter->emit(new DaemonStopped());
     }
 
     /**
@@ -106,6 +105,8 @@ class QueueHandlingDaemon implements Daemon, LoggerAwareInterface
         $this->logger->info('Closing daemon...');
 
         $this->driver->close();
+
+        $this->eventEmitter->emit(new DaemonStopped());
     }
 
     /**

--- a/src/Event/Listener/Metric/SendMetricOnMessageConsumed.php
+++ b/src/Event/Listener/Metric/SendMetricOnMessageConsumed.php
@@ -50,8 +50,12 @@ class SendMetricOnMessageConsumed implements ListenerInterface
             throw ListenerException::badEventGiven($event);
         }
 
+        $this->metricService->increment(
+            'daemon.message_consumed'
+        );
+
         $this->metricService->timing(
-            'daemon.message_consumed',
+            'daemon.message_processing_time',
             $this->clock->timestampInMs() - $this->messageReceivedAt
         );
     }

--- a/tests/unit/Daemon/QueueHandlingDaemonTest.php
+++ b/tests/unit/Daemon/QueueHandlingDaemonTest.php
@@ -87,7 +87,7 @@ class QueueHandlingDaemonTest extends \PHPUnit_Framework_TestCase
         $this->assertItWillEmitEvents();
         $this->assertMessageWillBeHandled();
         $this->assertDriverWillConsume();
-        $this->assertDriverWillBeClosedOnceConsumingIsOver();
+        $this->assertDriverWillBeClosed();
 
         $this->serviceUnderTest->start();
     }
@@ -102,12 +102,23 @@ class QueueHandlingDaemonTest extends \PHPUnit_Framework_TestCase
         $this->assertItWillEmitEvents();
         $this->assertMessageWillBeHandled();
         $this->assertDriverWillConsume();
-        $this->assertDriverWillBeClosedOnceConsumingIsOver();
+        $this->assertDriverWillBeClosed();
 
         $this->assertItWillMonitorTheConsumption();
 
         $this->serviceUnderTest->setMonitor($this->monitor);
         $this->serviceUnderTest->start();
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldEmitDaemonStoppedWhenStop()
+    {
+        $this->assertDriverWillBeClosed();
+        $this->assertItWillEmitDaemonStoppedEvent();
+
+        $this->serviceUnderTest->stop();
     }
 
     protected function givenHandlerWillReturnConsumeOptions()
@@ -140,7 +151,7 @@ class QueueHandlingDaemonTest extends \PHPUnit_Framework_TestCase
             );
     }
 
-    protected function assertDriverWillBeClosedOnceConsumingIsOver()
+    protected function assertDriverWillBeClosed()
     {
         $this->driver
             ->shouldReceive('close')
@@ -172,6 +183,14 @@ class QueueHandlingDaemonTest extends \PHPUnit_Framework_TestCase
             ->with(new MustBe(new MessageConsumed()))
             ->once();
 
+        $this->eventEmitter
+            ->shouldReceive('emit')
+            ->with(new MustBe(new DaemonStopped()))
+            ->once();
+    }
+
+    private function assertItWillEmitDaemonStoppedEvent()
+    {
         $this->eventEmitter
             ->shouldReceive('emit')
             ->with(new MustBe(new DaemonStopped()))

--- a/tests/unit/Event/Listener/Metric/Metric/SendMetricOnMessageConsumedTest.php
+++ b/tests/unit/Event/Listener/Metric/Metric/SendMetricOnMessageConsumedTest.php
@@ -49,8 +49,13 @@ class SendMetricOnMessageConsumedTest extends \PHPUnit_Framework_TestCase
     private function assertIncrementCalledOnMetricService()
     {
         $this->metricService
+            ->shouldReceive('increment')
+            ->with('daemon.message_consumed')
+            ->once();
+
+        $this->metricService
             ->shouldReceive('timing')
-            ->with('daemon.message_consumed', 0)
+            ->with('daemon.message_processing_time', 0)
             ->once();
     }
 


### PR DESCRIPTION
We need to know how much message have been consumed but also in how much time.

It is a best practice to have this metrics separated.