### PR TITLE
Add a way to create lazy SSL connections

### DIFF
--- a/src/Connection/PhpAmqpLib/AMQPLazySSLConnection.php
+++ b/src/Connection/PhpAmqpLib/AMQPLazySSLConnection.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Burrow\Connection\PhpAmqpLib;
+
+use PhpAmqpLib\Connection\AMQPSSLConnection;
+
+class AMQPLazySSLConnection extends AMQPSSLConnection
+{
+    /**
+     * Gets socket from current connection
+     *
+     * @deprecated
+     */
+    public function getSocket()
+    {
+        $this->connect();
+
+        return parent::getSocket();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function channel($channel_id = null)
+    {
+        $this->connect();
+
+        return parent::channel($channel_id);
+    }
+
+    /**
+     * @return null|\PhpAmqpLib\Wire\IO\AbstractIO
+     */
+    public function getIO()
+    {
+        if (empty($this->io)) {
+            $this->connect();
+        }
+
+        return $this->io;
+    }
+
+    /**
+     * Should the connection be attempted during construction?
+     *
+     * @return bool
+     */
+    public function connectOnConstruct()
+    {
+        return false;
+    }
+}

--- a/src/Driver/DriverFactory.php
+++ b/src/Driver/DriverFactory.php
@@ -2,9 +2,11 @@
 
 namespace Burrow\Driver;
 
+use Burrow\Connection\PhpAmqpLib\AMQPLazySSLConnection;
 use Burrow\Driver;
 use PhpAmqpLib\Connection\AbstractConnection;
 use PhpAmqpLib\Connection\AMQPLazyConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 class DriverFactory
 {
@@ -87,18 +89,29 @@ class DriverFactory
     /**
      * @param string[] $connection
      *
-     * @return AMQPLazyConnection
+     * @return AMQPStreamConnection
      *
      * @codeCoverageIgnore
      */
     protected static function getPhpAmqpLibConnection(array $connection)
     {
-        return new AMQPLazyConnection(
-            $connection['host'],
-            $connection['port'],
-            $connection['user'],
-            $connection['pwd']
-        );
+        if (isset($connection['ssl']) && $connection['ssl']) {
+            return new AMQPLazySSLConnection(
+                $connection['host'],
+                $connection['port'],
+                $connection['user'],
+                $connection['pwd'],
+                '/',
+                isset($connection['ssl_options']) ? $connection['ssl_options'] : []
+            );
+        } else {
+            return new AMQPLazyConnection(
+                $connection['host'],
+                $connection['port'],
+                $connection['user'],
+                $connection['pwd']
+            );
+        }
     }
 
     /**

--- a/src/Driver/DriverFactory.php
+++ b/src/Driver/DriverFactory.php
@@ -16,12 +16,18 @@ class DriverFactory
      * It accepts a PECL connection, a PhpAmqpLib connection or an array following
      * the following schema :
      * [
-     *     'host' => '<hostValue>',
-     *     'port' => '<portValue>',
-     *     'user' => '<userValue>',
-     *     'pwd'  => '<pwdValue>'
+     *     'host'        => '<hostValue>',
+     *     'port'        => '<portValue>',
+     *     'user'        => '<userValue>',
+     *     'pwd'         => '<pwdValue>',
+     *     'ssl'         => true,                   // Optional: default to false
+     *     'ssl_options' => [                       // Optional: default to [], see https://www.php.net/manual/context.ssl.php
+     *         'capath'      => '/etc/ssl/certs',
+     *         'verify_peer' => true,
+     *     ],
      * ]
      *
+     * SSL options is limited to PhpAmqpLib.
      * If you provide an array, the PECL extension has precedence over the PhpAmqpLib.
      *
      * @param $connection


### PR DESCRIPTION
# Description

Add a way to create lazy SSL connection from an array of config.

PhpAmqpLib does not yet provide a way to lazy connect, it would be a good idea to contribute to https://github.com/php-amqplib/php-amqplib/issues/582